### PR TITLE
Add Splash display

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,17 +1,37 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 
 import Errors from './components/errors/Errors';
 import Pods from './components/pods/Pods';
+import Splash from './components/splash/Splash';
 
 // TODO: after MVP, convert React Class Components to Hooks.
 // TODO: after MVP, try out Typescript.
 
-const App = () => (
-  <div>
-    <h1>Kubiquity</h1>
-    <Errors />
-    <Pods />
-  </div>
-);
+const App = () => {
+  const [
+    isSplashShowing,
+    setIsSplashShowing
+  ] = useState(true);
+
+  useEffect(() => {
+    setTimeout(() => {
+      setIsSplashShowing(false);
+    }, 800);
+  }, []);
+
+  if (isSplashShowing) {
+    return (
+      <Splash />
+    )
+  }
+
+  return (
+    <div>
+      <h1>Kubiquity</h1>
+      <Errors />
+      <Pods />
+    </div>
+  )
+};
 
 export default App;

--- a/src/components/splash/Splash.jsx
+++ b/src/components/splash/Splash.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Splash = () => (
+  <>
+    <h1>Kubiquity</h1>
+    <div>Developed by k8sm8s, 2021</div>
+    <div>App is loading; please wait . . . </div>
+  </>
+);
+
+export default Splash;


### PR DESCRIPTION
WHAT DOES THIS PR DO? 
1. Adds a Splash page for our app. 

HOW TO TEST THIS PR:
1. Run the following command: `gh pr checkout 9 && npm install && npm run watch`
2. In a second terminal, run `npm start`. 
3. Verify that the app opens and that you see the splash page, then the splash page transitions to the real app. 

ADDITIONAL NOTES: 
1. I wonder if there's a way to take advantage of loading our errors data here. Probably would be easy to figure out, that way we don't have two loading screens. 
2. Lmk if the splash page shows up for too long or too short time. 