### PR TITLE
BE Styling fixes, remove unused node packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@kubernetes/client-node": "^0.15.0",
         "apexcharts": "^3.27.1",
-        "child_process": "^1.0.2",
         "dotenv": "^10.0.0",
         "electron": "^13.1.4",
         "express": "^4.17.1",
@@ -19,7 +18,6 @@
         "node-cmd": "^4.0.0",
         "node-fetch": "^2.6.1",
         "path": "^0.12.7",
-        "prom-client": "^13.1.0",
         "react": "^17.0.2",
         "react-apexcharts": "^1.3.9",
         "react-dom": "^17.0.2",
@@ -2693,11 +2691,6 @@
         "file-uri-to-path": "1.0.0"
       }
     },
-    "node_modules/bintrees": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
-      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
-    },
     "node_modules/bl": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
@@ -3101,11 +3094,6 @@
       "engines": {
         "node": ">=0.8.0"
       }
-    },
-    "node_modules/child_process": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
-      "integrity": "sha1-sffn/HPSXn/R1FWtyU4UODAYK1o="
     },
     "node_modules/chokidar": {
       "version": "3.5.2",
@@ -8933,17 +8921,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/prom-client": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-13.1.0.tgz",
-      "integrity": "sha512-jT9VccZCWrJWXdyEtQddCDszYsiuWj5T0ekrPszi/WEegj3IZy6Mm09iOOVM86A4IKMWq8hZkT2dD9MaSe+sng==",
-      "dependencies": {
-        "tdigest": "^0.1.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/prop-types": {
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
@@ -10842,14 +10819,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/tdigest": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
-      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
-      "dependencies": {
-        "bintrees": "1.0.1"
       }
     },
     "node_modules/term-size": {
@@ -14743,11 +14712,6 @@
         "file-uri-to-path": "1.0.0"
       }
     },
-    "bintrees": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
-      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
-    },
     "bl": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
@@ -15088,11 +15052,6 @@
           "dev": true
         }
       }
-    },
-    "child_process": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
-      "integrity": "sha1-sffn/HPSXn/R1FWtyU4UODAYK1o="
     },
     "chokidar": {
       "version": "3.5.2",
@@ -19809,14 +19768,6 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
-    "prom-client": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-13.1.0.tgz",
-      "integrity": "sha512-jT9VccZCWrJWXdyEtQddCDszYsiuWj5T0ekrPszi/WEegj3IZy6Mm09iOOVM86A4IKMWq8hZkT2dD9MaSe+sng==",
-      "requires": {
-        "tdigest": "^0.1.1"
-      }
-    },
     "prop-types": {
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
@@ -21402,14 +21353,6 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         }
-      }
-    },
-    "tdigest": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
-      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
-      "requires": {
-        "bintrees": "1.0.1"
       }
     },
     "term-size": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "dependencies": {
     "@kubernetes/client-node": "^0.15.0",
     "apexcharts": "^3.27.1",
-    "child_process": "^1.0.2",
     "dotenv": "^10.0.0",
     "electron": "^13.1.4",
     "express": "^4.17.1",
@@ -33,7 +32,6 @@
     "node-cmd": "^4.0.0",
     "node-fetch": "^2.6.1",
     "path": "^0.12.7",
-    "prom-client": "^13.1.0",
     "react": "^17.0.2",
     "react-apexcharts": "^1.3.9",
     "react-dom": "^17.0.2",

--- a/server/controllers/metricsController.js
+++ b/server/controllers/metricsController.js
@@ -1,11 +1,10 @@
-const { spawn } = require('child_process');
 const fetch = require('node-fetch');
 
 const metricsController = {};
 
 const PROM_URL = 'http://127.0.0.1:9090/api/v1/';
 
-metricsController.getMemory = (req, res, next) => {
+metricsController.getMemory = async (req, res, next) => {
   try {
     // create query at current time
     const currentDate = new Date().toISOString();
@@ -13,24 +12,23 @@ metricsController.getMemory = (req, res, next) => {
     query += `&start=${currentDate}&end=${currentDate}&step=1m`;
     let memArr;
     // send query to prometheus for node memory usage
-    const data = fetch(PROM_URL + query)
-      .then(data => data.json())
-      .then(results => {
-        memArr = results.data.result[0].values[0];
-        // format results and change into megabytes
-        memArr.forEach((el, ind) => {
-          if (typeof el === 'string') el = parseFloat(el);
-          mbMemory = el / 1048576;
-          memArr[ind] = Math.floor(mbMemory);
-        });
-      });
+    const data = await fetch(PROM_URL + query);
+    const results = await data.json();
+    // format results and change into megabytes
+    memArr = results.data.result[0].values[0];
+    memArr.forEach((el, ind) => {
+      if (typeof el === 'string') el = parseFloat(el);
+      mbMemory = el / 1048576;
+      memArr[ind] = Math.floor(mbMemory);
+    });
+    
     // convert array into object to send to front end
     const memObj = Object.assign({}, memArr);
-    const formattedData = [];
-    Object.entries(memObj).forEach(([key, value]) => {
-      const formattedObj = { podId: key, memory: value };
-      formattedData.push(formattedObj);
-    });
+    const formattedData = Object.entries(memObj).map(([podId, memory]) => ({
+      podId, 
+      memory
+    }));
+
     res.locals.memory = formattedData;
     return next();
   } catch (err) {

--- a/server/routers/metricsRouter.js
+++ b/server/routers/metricsRouter.js
@@ -3,7 +3,8 @@ const metricsController = require('../controllers/metricsController');
 
 const router = express.Router();
 
-router.get('/', 
+router.get(
+  '/', 
   metricsController.getMemory, 
   (req, res) => res.status(200).json(res.locals.memory)
 );


### PR DESCRIPTION
WHAT DOES THIS PR DO?

1. changed to use async await instead of .then
2. Changed to use Object.map instead of iterating and pushing into array
3. Styling changes from previous PR
4. Remove extra unused node packages

HOW TO TEST THIS PR:

1. Run the following command: `gh pr checkout 19 && npm install`
2. Make sure to have docker and minikube running.
3. Install helm with `brew install helm`.
4. Make sure prometheus is running (instructions in #17 ).
5. Expose prometheus port with `export POD_NAME=$(kubectl get pods --namespace prometheus -l "app=prometheus,component=server" -o jsonpath="{.items[0].metadata.name}") && kubectl --namespace prometheus port-forward $POD_NAME 9090`
6. Run `npm run backend`
7. Using Postman or Thunder Client, send a request to localhost:3000/metrics and localhost:3000/errors to confirm that event logs show up and the memory usage of nodes show up.

