### PR TITLE
Update getMemory and MetricsTable

### DIFF
--- a/backend/controllers/metricsController.js
+++ b/backend/controllers/metricsController.js
@@ -46,7 +46,7 @@ metricsController.getMemory = async () => {
   if (!isPromUp) await forwardPromPort();
 
   const currentDate = new Date().toISOString();
-  const query = `/query_range?query=sum(rate(container_memory_usage_bytes[2m])) by (pod) &start=${currentDate}&end=${currentDate}&step=1m`;
+  const query = `query_range?query=sum(rate(container_memory_usage_bytes[2m])) by (pod) &start=${currentDate}&end=${currentDate}&step=1m`;
 
   try {
     const data = await fetch(PROM_URL + query);
@@ -54,14 +54,21 @@ metricsController.getMemory = async () => {
     const memArr = results.data.result;
 
     // format results and change into bytes
-    const mappedData = memArr.filter(metrics => {
-      if (metrics.values[0][1] != 0 || !metrics.metric.pod){
+    return memArr.reduce((pods, metrics) => {
+      // console.log(metrics);
+      if (metrics.values[0][1] > 0 && metrics.metric.pod) {
         const memory = parseFloat(metrics.values[0][1]);
-        return {podId: metrics.metric.pod, memory}
+
+        const pod = {
+          podId: metrics.metric.pod,
+          memory,
+        };
+
+        pods.push(pod);
       }
-    });
-    // removes first element that has an undefined podId
-    return formattedData;
+
+      return pods;
+    }, []).sort((a, b) => b.memory - a.memory);
   } catch (err) {
     // TODO: add proper error handling. 
     console.log(`metricsController.getMemory: ERROR: ${err}`);

--- a/backend/controllers/metricsController.js
+++ b/backend/controllers/metricsController.js
@@ -55,7 +55,6 @@ metricsController.getMemory = async () => {
 
     // format results and change into bytes
     return memArr.reduce((pods, metrics) => {
-      // console.log(metrics);
       if (metrics.values[0][1] > 0 && metrics.metric.pod) {
         const memory = parseFloat(metrics.values[0][1]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11901,6 +11901,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -61,12 +61,12 @@ const App = () => {
     }, 4850);
 
     // TODO: to test actual K8s cluster, uncomment 56 and comment out 55. 
-    window.api.send(GET_LOG_TEST);
-    // window.api.send(GET_LOG);
+    // window.api.send(GET_LOG_TEST);
+    window.api.send(GET_LOG);
 
     // TODO: to test actual K8s cluster, comment out 59 and uncomment 60. 
-    setMetrics(MOCK_PODS);
-    // window.api.send(GET_METRICS);
+    // setMetrics(MOCK_PODS);
+    window.api.send(GET_METRICS);
   }, []);
 
   if (isSplashShowing) return (<Splash />);

--- a/src/components/metrics/MemoryBarChart.jsx
+++ b/src/components/metrics/MemoryBarChart.jsx
@@ -30,13 +30,7 @@ const PLOT_OPTIONS = {
 };
 
 const X_AXIS_LABELS = {
-  formatter: val => `${val} MB`,
-};
-
-const Y_AXIS = {
-  labels: {
-    formatter: val => `Pod ${val}`,
-  },
+  formatter: val => `${val} B`,
 };
 
 const MemoryBarChart = ({ data, categories }) => {
@@ -48,7 +42,6 @@ const MemoryBarChart = ({ data, categories }) => {
     chart: CHART,
     plotOptions: PLOT_OPTIONS,
     dataLabels: ENABLED_FALSE,
-    yaxis: Y_AXIS,
     xaxis: {
       categories,
       labels: X_AXIS_LABELS,


### PR DESCRIPTION
WHAT DOES THIS PR DO? 
1. Updates getMetrics to correctly get metrics. 
2. Updates MetricsTable. 

HOW TO TEST THIS PR:
1. The app is currently in non-testing mode, so please start Docker desktop and run `minikube start`. 
2. Once 1 is fully done, run `gh pr checkout 34 && npm install && npm run build && npm start`
3. Verify that the pod metrics are coming to the app. 
4. BACKEND TEAM: verify that the getMetrics function is correctly "filtering" the way you intended. 

ADDITIONAL NOTES: 
1. Would it be more semantic to name our `podId` something else now? Like `name`? Or `namespace`?
