### PR TITLE
Add cpu middleware to electron backend and convert to array of objects

### DIFF
--- a/backend/controllers/metricsController.js
+++ b/backend/controllers/metricsController.js
@@ -72,21 +72,20 @@ metricsController.getCPU = async () => {
   // create query at current time
   const currentDate = new Date().toISOString();
   const query = `query_range?query=sum(rate(container_cpu_usage_seconds_total{image!=""}[2m])) by (pod)&start=${currentDate}&end=${currentDate}&step=1m`;
-  
+
   try {
-    let cpuArr;
     // send query to prometheus for pod cpu usage
     const data = await fetch(PROM_URL + query);
     const results = await data.json();
     // format results
-    cpuArr = results.data.result;
+    const cpuArr = results.data.result;
     cpuArr.forEach((el, ind) => {
       let podID = el.metric.pod;
       let cpuPercent = el.values[0][1] * 100;
       cpuArr[ind] = { podID, cpuUsage: cpuPercent };
     });
 
-    return cpuArr;
+    return cpuArr.sort((a, b) => b.cpuUsage - a.cpuUsage);
   } catch (err) {
     // TODO: add proper error handling. 
     console.log(`metricsController.getCPU: ERROR: ${err}`);

--- a/backend/controllers/metricsController.js
+++ b/backend/controllers/metricsController.js
@@ -68,4 +68,29 @@ metricsController.getMemory = async () => {
   }
 };
 
+metricsController.getCPU = async () => {
+  // create query at current time
+  const currentDate = new Date().toISOString();
+  const query = `query_range?query=sum(rate(container_cpu_usage_seconds_total{image!=""}[2m])) by (pod)&start=${currentDate}&end=${currentDate}&step=1m`;
+  
+  try {
+    let cpuArr;
+    // send query to prometheus for pod cpu usage
+    const data = await fetch(PROM_URL + query);
+    const results = await data.json();
+    // format results
+    cpuArr = results.data.result;
+    cpuArr.forEach((el, ind) => {
+      let podID = el.metric.pod;
+      let cpuPercent = el.values[0][1] * 100;
+      cpuArr[ind] = { podID, cpuUsage: cpuPercent };
+    });
+
+    return cpuArr;
+  } catch (err) {
+    // TODO: add proper error handling. 
+    console.log(`metricsController.getCPU: ERROR: ${err}`);
+  }
+};
+
 module.exports = metricsController;

--- a/server/controllers/metricsController.js
+++ b/server/controllers/metricsController.js
@@ -83,20 +83,19 @@ metricsController.getCPU = async (req, res, next) => {
   const query = `query_range?query=sum(rate(container_cpu_usage_seconds_total{image!=""}[2m])) by (pod)&start=${currentDate}&end=${currentDate}&step=1m`;
 
   try {
-    let cpuArr;
     // send query to prometheus for pod cpu usage
     const data = await fetch(PROM_URL + query);
     const results = await data.json();
     // format results
-    cpuArr = results.data.result;
+    const cpuArr = results.data.result;
     cpuArr.forEach((el, ind) => {
       let podID = el.metric.pod;
       let cpuPercent = el.values[0][1] * 100;
       cpuArr[ind] = { podID, cpuUsage: cpuPercent };
     });
     console.log(cpuArr);
-    res.locals.cpu = cpuArr;
-    
+    res.locals.cpu = cpuArr.sort((a, b) => b.cpuUsage - a.cpuUsage);
+
     return next();
   } catch (err) {
     return next({

--- a/server/controllers/metricsController.js
+++ b/server/controllers/metricsController.js
@@ -78,11 +78,11 @@ metricsController.getMemory = async (req, res, next) => {
 };
 
 metricsController.getCPU = async (req, res, next) => {
+  // create query at current time
+  const currentDate = new Date().toISOString();
+  const query = `query_range?query=sum(rate(container_cpu_usage_seconds_total{image!=""}[2m])) by (pod)&start=${currentDate}&end=${currentDate}&step=1m`;
+
   try {
-    // create query at current time
-    const currentDate = new Date().toISOString();
-    let query = `query_range?query=sum(rate(container_cpu_usage_seconds_total{image!=""}[2m])) by (pod)`;
-    query += `&start=${currentDate}&end=${currentDate}&step=1m`;
     let cpuArr;
     // send query to prometheus for pod cpu usage
     const data = await fetch(PROM_URL + query);
@@ -90,12 +90,13 @@ metricsController.getCPU = async (req, res, next) => {
     // format results
     cpuArr = results.data.result;
     cpuArr.forEach((el, ind) => {
-      let podID = el.metric.pod
-      let cpuPercent = el.values[0][1];
-      cpuArr[ind] = {[podID]: cpuPercent}
+      let podID = el.metric.pod;
+      let cpuPercent = el.values[0][1] * 100;
+      cpuArr[ind] = { podID, cpuUsage: cpuPercent };
     });
     console.log(cpuArr);
     res.locals.cpu = cpuArr;
+    
     return next();
   } catch (err) {
     return next({


### PR DESCRIPTION
WHAT DOES THIS PR DO?

- Add getCpu middleware to backend metrics controller
- Convert cpu usage to percentage 
- Convert output to array of objects in the format `{ podId: pod, cpuUsage: percentage}`

HOW TO TEST THIS PR:

- Currently no CPU usage chart is available to test if the front end is receiving the data correctly.

- Can test what the output looks like by running `gh pr checkout 35 && npm install && npm run backend`.
- Send GET request to `/metrics' endpoint and verify the console logs are in the correct format
