### PR TITLE
Add electron json store

### DIFF
--- a/backend/controllers/logController.js
+++ b/backend/controllers/logController.js
@@ -87,6 +87,7 @@ logController.saveLog = async (log) => {
     storage.set('logs', {data: allLogs}, (err) => {
       if (err) throw err;
     });
+
     return;
   } catch (err) {
     console.log(err);
@@ -96,6 +97,7 @@ logController.saveLog = async (log) => {
 logController.getLog = async () => {
   try {
     const logs = await storage.getSync('logs');
+    
     return logs.data;
   } catch (err) {
     console.log(err);

--- a/backend/controllers/logController.js
+++ b/backend/controllers/logController.js
@@ -82,14 +82,11 @@ logController.saveLog = async (log) => {
         createdAt
       };
       allLogs.push(newEntry);
-      return entryPromise;
     });
 
-    await Promise.all(logPromises);
     storage.set('logs', {data: allLogs}, (err) => {
       if (err) throw err;
     });
-    
     return;
   } catch (err) {
     console.log(err);

--- a/backend/controllers/metricsController.js
+++ b/backend/controllers/metricsController.js
@@ -46,7 +46,7 @@ metricsController.getMemory = async () => {
   if (!isPromUp) await forwardPromPort();
 
   const currentDate = new Date().toISOString();
-  const query = `/query_range?query=sum(rate(container_memory_usage_bytes[2m])) by (pod) &start=${currentDate}&end=${currentDate}&step=1m`;
+  const query = `query_range?query=sum(rate(container_memory_usage_bytes[2m])) by (pod) &start=${currentDate}&end=${currentDate}&step=1m`;
 
   try {
     const data = await fetch(PROM_URL + query);

--- a/backend/index.js
+++ b/backend/index.js
@@ -10,7 +10,6 @@ const {
 const getLogTest = async () => await fetchLog();
 const getMetrics = async () =>  await getMemory();
 const getLog = async () => {
-  await clearLog();
   let log = await queryLog();
   log = formatLog(log);
   await saveLog(log);


### PR DESCRIPTION
WHAT DOES THIS PR DO:

- Server is no longer needed and all data storage is done locally
- Implement electron-json-store package

HOW TO TEST THIS PR:

- `gh pr checkout 39 && npm install && npm run dev`
- verify that the table of logs shows up correctly. 

ADDITIONAL NOTES:

Removed the clear logs middleware since the whole file is essentially being overwritten by the saveLog middleware every time which means it can't duplicate logs.